### PR TITLE
Start porting to emake, fix lint

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -167,12 +167,18 @@ jobs:
       - *install-emake
       - name: Building executable
         run: |
+          make vbuild/cli/__names__.py
           emake build \
             --executable \
             --arch ${{ matrix.arch }} \
             --libc ${{ matrix.libc }} \
             --python ${{ matrix.python }} \
             ${{ matrix.nocompress && '--no-compress' || '' }}
+      - name: Rename executable
+        run: |
+          set -e
+          cd dist
+          mv vbuild-${{ matrix.arch }}-*-${{ matrix.libc }} vbuild
       - uses: actions/upload-artifact@v6
         with:
           name: vbuild-${{ matrix.arch }}-${{ matrix.libc }}
@@ -188,11 +194,13 @@ jobs:
     strategy:
       matrix:
         path: ${{ fromJson(needs.test_matrix.outputs.paths) }}
-        driver:
-          - podman
-          - docker
-        os:
-          - ubuntu
+        python:
+          - "3.14"
+        arch:
+          - x86_64
+        libc:
+          - glibc
+          - musl
       fail-fast: false
     steps:
       - name: Checkout the Git repository
@@ -201,10 +209,9 @@ jobs:
         id: download
         uses: actions/download-artifact@v8
         with:
-          name: vbuild-${{ matrix.os }}
+          name: vbuild-${{ matrix.arch }}-${{ matrix.libc }}
           path: dist
       - name: Run vbuild
-        if: matrix.os != 'alpine'
         shell: bash
         run: |
           set -e
@@ -212,37 +219,48 @@ jobs:
             echo "SKIPPED"
             exit 0
           fi
+          image="python:${{ matrix.python }}"
+          if [[ "${{ matrix.libc }}" == "musl" ]];then
+            image="${image}-alpine"
+          fi
           if [ "$driver" == 'podman' ];then
             echo "Starting podman service..."
-            sudo mkdir -p /run/user/"$(id -u)"/podman
-            socketdir=/run/user/"$(id -u)"/podman
-            sudo chown "$(id -u):$(id -g)" "$socketdir"
-            podman system service --time 0 unix://"$socketdir/podman.sock" &
+            sudo mkdir -p /run/podman
+            podman system service --time 0 unix:///run/podman/podman.sock &
             tries=0
-            while [ ! -S "$socketdir/podman.sock" ] && [ $tries -lt 60 ];do
+            while [ ! -S "/run/podman/podman.sock" ] && [ $tries -lt 60 ];do
               tries=$(( tries + 1 ))
               sleep 0.1
             done
           fi
-          echo "Running vbuild..."
-          chmod +x dist/vbuild
-          action=all
-          if [ -f "tests/${{ matrix.path }}/action" ];then
-            action="$(cat "tests/${{ matrix.path }}/action")"
-          fi
-          CARCH=noarch
-          if [ -f "tests/${{ matrix.path }}/arch" ];then
-            CARCH="$(cat "tests/${{ matrix.path }}/arch")"
-          fi
-          CARCH=$CARCH \
-          VBUILD_DRIVER=$driver \
-          dist/vbuild -C "tests/${{ matrix.path }}" "$action"
+          docker run \
+            --rm \
+            --volume=$(pwd):/src \
+            --volume=/run/docker.sock:/run/docker.sock \
+            --volume=/run/podman:/run/podman \
+            "$image" \
+            sh -ec "$script"
           if [ "$driver" == 'podman' ];then
             echo "Stopping podman service..."
             kill $(jobs -p) || true
           fi
         env:
           driver: ${{ matrix.driver }}
+          script: |
+            cd /src
+            echo "Running vbuild..."
+            chmod +x dist/vbuild
+            action=all
+            if [ -f "tests/${{ matrix.path }}/action" ];then
+              action="$(cat "tests/${{ matrix.path }}/action")"
+            fi
+            CARCH=noarch
+            if [ -f "tests/${{ matrix.path }}/arch" ];then
+              CARCH="$(cat "tests/${{ matrix.path }}/arch")"
+            fi
+            CARCH=$CARCH \
+            VBUILD_DRIVER=$driver \
+            dist/vbuild -C "tests/${{ matrix.path }}" "$action"
       - name: Validate output
         if: "!cancelled()"
         shell: bash

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -279,9 +279,25 @@ jobs:
             echo "SKIPPED"
             exit 0
           fi
-          if [ -f tests/${{ matrix.path }}/validate.sh ];then
-            tests/${{ matrix.path }}/validate.sh
+          image="python:${{ matrix.python }}"
+          if [[ "${{ matrix.libc }}" == "musl" ]];then
+            image="${image}-alpine"
           fi
+          docker run \
+            --rm \
+            --volume=$(pwd):$(pwd) \
+            --env=srcdir=$(pwd) \
+            "$image" \
+            sh -ec "$script"
+        env:
+          script: |
+            cd $srcdir
+            if [[ "${{matrix.libc }}" == "musl" ]];then
+              apk add --no-cache bash
+            fi
+            if [ -f tests/${{ matrix.path }}/validate.sh ];then
+              tests/${{ matrix.path }}/validate.sh
+            fi
 
   release:
     name: Add ${{ matrix.artifact }} to release

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -144,65 +144,39 @@ jobs:
             tests/${{ matrix.path }}/validate.sh
           fi
 
-  build-executable-ubuntu:
-    name: Build executable for ubuntu
-    needs: &test-needs
+  build-executable:
+    name: Build executable
+    needs:
       - unit_test
       - test_python
       - lint
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python:
+          - "3.11"
+        arch:
+          - x86_64
+        libc:
+          - glibc
+          - musl
     steps:
       - name: Checkout the Git repository
         uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: 3.14
-          cache: "pip"
-      - name: Install ccache
-        uses: Eeems-Org/apt-cache-action@v1.5
-        with:
-          packages: ccache
-      - name: Nuitka ccache
-        uses: actions/cache@v5
-        with:
-          path: ${{ github.workspace }}/.nuitka
-          key: ${{ github.job }}-ccache-ubuntu-latest
       - *install-emake
-      - name: Build with nuitka
-        run: make executable
+      - name: Building executable
+        run: |
+          emake build \
+            --executable \
+            --arch ${{ matrix.arch }} \
+            --libc ${{ matrix.libc }} \
+            --python ${{ matrix.python }} \
+            ${{ matrix.nocompress && '--no-compress' || '' }}
       - uses: actions/upload-artifact@v6
         with:
-          name: vbuild-ubuntu
-          path: dist
-          if-no-files-found: error
-
-  build-executable-alpine:
-    name: Build executable for alpine
-    needs: *test-needs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout the Git repository
-        uses: actions/checkout@v6
-      - uses: jirutka/setup-alpine@v1
-        with:
-          branch: v3.23
-          packages: >
-            build-base python3 python3-dev py3-pip py3-wheel ccache git patchelf upx bash
-      - name: Nuitka ccache
-        uses: actions/cache@v5
-        with:
-          path: ${{ github.workspace }}/.nuitka
-          key: ${{ github.job }}-ccache-alpine
-      - name: Install emake
-        run: pip install --break-system-packages emake
-        shell: alpine.sh {0}
-      - name: Build with nuitka
-        shell: alpine.sh {0}
-        run: make executable
-      - uses: actions/upload-artifact@v6
-        with:
-          name: vbuild-alpine
-          path: dist
+          name: vbuild-${{ matrix.arch }}-${{ matrix.libc }}
+          path: dist/*
           if-no-files-found: error
 
   test_executable:
@@ -210,8 +184,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - test_matrix
-      - build-executable-ubuntu
-      - build-executable-alpine
+      - build-executable
     strategy:
       matrix:
         path: ${{ fromJson(needs.test_matrix.outputs.paths) }}
@@ -291,8 +264,8 @@ jobs:
     strategy:
       matrix:
         artifact:
-          - "vbuild-ubuntu"
-          - "vbuild-alpine"
+          - "vbuild-x86_64-glibc"
+          - "vbuild-x86_64-musl"
     permissions:
       contents: write
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -233,11 +233,14 @@ jobs:
               sleep 0.1
             done
           fi
+          sudo mkdir -p /root/.config/vbuild
           docker run \
             --rm \
-            --volume=$(pwd):/src \
+            --volume=$(pwd):$(pwd) \
             --volume=/run/docker.sock:/run/docker.sock \
             --volume=/run/podman:/run/podman \
+            --volume=/root/.config/vbuild:/root/.config/vbuild \
+            --environment=srcdir=$(pwd) \
             "$image" \
             sh -ec "$script"
           if [ "$driver" == 'podman' ];then
@@ -247,9 +250,12 @@ jobs:
         env:
           driver: ${{ matrix.driver }}
           script: |
-            cd /src
+            cd $srcdir
             if [[ "${{ matrix.libc }}" == "musl" ]];then
-              apk add --no-cache bash openssl
+              apk add --no-cache \
+                bash \
+                openssl \
+                ${{ matrix.driver }}
             fi
             echo "Running vbuild..."
             chmod +x dist/vbuild

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -248,6 +248,9 @@ jobs:
           driver: ${{ matrix.driver }}
           script: |
             cd /src
+            if [[ "${{ matrix.libc }}" == "musl" ]];then
+              apk add --no-cache bash openssl
+            fi
             echo "Running vbuild..."
             chmod +x dist/vbuild
             action=all

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -194,7 +194,7 @@ jobs:
           path: ${{ github.workspace }}/.nuitka
           key: ${{ github.job }}-ccache-alpine
       - name: Install emake
-        run: pip install emake
+        run: pip install --break-system-packages emake
         shell: alpine.sh {0}
       - name: Build with nuitka
         shell: alpine.sh {0}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,9 +6,32 @@ on:
   pull_request:
   workflow_dispatch:
   release:
-    types: [released]
+    types: [ released ]
 permissions: read-all
 jobs:
+  lint:
+    name: Lint codebase
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: &python-versions
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+    steps:
+      - name: Checkout the Git repository
+        uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{{{ matrix.python }}}}
+          cache: pip
+      - &install-emake
+        name: Install emake
+        run: pip install emake
+      - name: Run lint
+        run: emake lint
+
   test_matrix:
     name: Build test matrix
     runs-on: ubuntu-latest
@@ -41,6 +64,7 @@ jobs:
         python:
           - "3.12"
           - "3.13"
+          - "3.14"
       fail-fast: false
     steps:
       - name: Checkout the Git repository
@@ -124,16 +148,17 @@ jobs:
 
   build-executable-ubuntu:
     name: Build executable for ubuntu
-    needs:
+    needs: &test-needs
       - unit_test
       - test_python
+      - lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the Git repository
         uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: 3.13
+          python-version: 3.14
           cache: "pip"
       - name: Install ccache
         uses: Eeems-Org/apt-cache-action@v1.5
@@ -154,9 +179,7 @@ jobs:
 
   build-executable-alpine:
     name: Build executable for alpine
-    needs:
-      - unit_test
-      - test_python
+    needs: *test-needs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the Git repository
@@ -165,16 +188,7 @@ jobs:
         with:
           branch: v3.23
           packages: >
-            build-base
-            python3
-            python3-dev
-            py3-pip
-            py3-wheel
-            ccache
-            git
-            patchelf
-            upx
-            bash
+            build-base python3 python3-dev py3-pip py3-wheel ccache git patchelf upx bash
       - name: Nuitka ccache
         uses: actions/cache@v5
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -240,7 +240,7 @@ jobs:
             --volume=/run/docker.sock:/run/docker.sock \
             --volume=/run/podman:/run/podman \
             --volume=/root/.config/vbuild:/root/.config/vbuild \
-            --environment=srcdir=$(pwd) \
+            --env=srcdir=$(pwd) \
             "$image" \
             sh -ec "$script"
           if [ "$driver" == 'podman' ];then

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -201,6 +201,9 @@ jobs:
         libc:
           - glibc
           - musl
+        driver:
+          - podman
+          - docker
       fail-fast: false
     steps:
       - name: Checkout the Git repository
@@ -300,39 +303,32 @@ jobs:
             fi
 
   release:
-    name: Add ${{ matrix.artifact }} to release
+    name: Add release artifacts
     if: github.repository == 'Eeems/vbuild' && github.event_name == 'release' && startsWith(github.ref, 'refs/tags')
-    needs: test_executable
+    needs:
+      - test_executable
+      - build-executable
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        artifact:
-          - "vbuild-x86_64-glibc"
-          - "vbuild-x86_64-musl"
     permissions:
       contents: write
     steps:
       - name: Checkout the Git repository
         uses: actions/checkout@v6
-      - name: Download executable
+      - name: Download artifact
         id: download
         uses: actions/download-artifact@v8
         with:
-          name: ${{ matrix.artifact }}
+          pattern: pip-*
+          merge-multiple: true
           path: dist
+      - name: Download executables
+        uses: actions/download-artifact@v8
+        with:
+          pattern: executable-*
+          merge-multiple: true
+          path: ${{ steps.download.outputs.download-path }}
       - name: Upload to release
-        run: |
-          if [ -f vbuild ]; then
-            name="vbuild-${{ matrix.artifact }}"
-            mv vbuild "$name"
-            gh release upload "$TAG" "$name" --clobber
-          elif [ -f vbuild-portable ]; then
-            name="vbuild-${{ matrix.artifact }}"
-            mv vbuild-portable "$name"
-            gh release upload "$TAG" "$name" --clobber
-          else
-            find . -type f | xargs -rI {} gh release upload "$TAG" {} --clobber
-          fi
+        run: find . -type f | xargs -rI { gh release upload "$TAG" {} --clobber
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.event.release.tag_name }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -155,7 +155,7 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - "3.11"
+          - "3.14"
         arch:
           - x86_64
         libc:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,6 @@ jobs:
     strategy:
       matrix:
         python: &python-versions
-          - "3.11"
           - "3.12"
           - "3.13"
           - "3.14"
@@ -24,7 +23,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: ${{{{ matrix.python }}}}
+          python-version: ${{ matrix.python }}
           cache: pip
       - &install-emake
         name: Install emake
@@ -61,10 +60,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python:
-          - "3.12"
-          - "3.13"
-          - "3.14"
+        python: *python-versions
       fail-fast: false
     steps:
       - name: Checkout the Git repository
@@ -73,6 +69,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           cache: "pip"
+      - *install-emake
       - name: Run tests
         run: make test
 
@@ -92,8 +89,9 @@ jobs:
         uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: 3.13
+          python-version: 3.14
           cache: "pip"
+      - *install-emake
       - name: Run vbuild
         run: |
           set -e
@@ -114,7 +112,7 @@ jobs:
             done
           fi
           echo "Running vbuild..."
-          make .venv/bin/activate
+          emake requirements
           source .venv/bin/activate
           action=all
           if [ -f "tests/${{ matrix.path }}/action" ];then
@@ -169,6 +167,7 @@ jobs:
         with:
           path: ${{ github.workspace }}/.nuitka
           key: ${{ github.job }}-ccache-ubuntu-latest
+      - *install-emake
       - name: Build with nuitka
         run: make executable
       - uses: actions/upload-artifact@v6
@@ -194,6 +193,9 @@ jobs:
         with:
           path: ${{ github.workspace }}/.nuitka
           key: ${{ github.job }}-ccache-alpine
+      - name: Install emake
+        run: pip install emake
+        shell: alpine.sh {0}
       - name: Build with nuitka
         shell: alpine.sh {0}
         run: make executable

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,7 +181,7 @@ jobs:
           mv vbuild-${{ matrix.arch }}-*-${{ matrix.libc }} vbuild
       - uses: actions/upload-artifact@v6
         with:
-          name: vbuild-${{ matrix.arch }}-${{ matrix.libc }}
+          name: executable-${{ matrix.arch }}-${{ matrix.libc }}
           path: dist/*
           if-no-files-found: error
 
@@ -212,7 +212,7 @@ jobs:
         id: download
         uses: actions/download-artifact@v8
         with:
-          name: vbuild-${{ matrix.arch }}-${{ matrix.libc }}
+          name: executable-${{ matrix.arch }}-${{ matrix.libc }}
           path: dist
       - name: Run vbuild
         shell: bash
@@ -328,7 +328,7 @@ jobs:
           merge-multiple: true
           path: ${{ steps.download.outputs.download-path }}
       - name: Upload to release
-        run: find . -type f | xargs -rI { gh release upload "$TAG" {} --clobber
+        run: find . -type f | xargs -rI {} gh release upload "$TAG" {} --clobber
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.event.release.tag_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -295,7 +295,7 @@ jobs:
         env:
           script: |
             cd $srcdir
-            if [[ "${{matrix.libc }}" == "musl" ]];then
+            if [[ "${{ matrix.libc }}" == "musl" ]];then
               apk add --no-cache bash
             fi
             if [ -f tests/${{ matrix.path }}/validate.sh ];then
@@ -314,19 +314,13 @@ jobs:
     steps:
       - name: Checkout the Git repository
         uses: actions/checkout@v6
-      - name: Download artifact
-        id: download
-        uses: actions/download-artifact@v8
-        with:
-          pattern: pip-*
-          merge-multiple: true
-          path: dist
       - name: Download executables
+        id: download
         uses: actions/download-artifact@v8
         with:
           pattern: executable-*
           merge-multiple: true
-          path: ${{ steps.download.outputs.download-path }}
+          path: dist
       - name: Upload to release
         run: find . -type f | xargs -rI {} gh release upload "$TAG" {} --clobber
         env:

--- a/Makefile
+++ b/Makefile
@@ -15,14 +15,17 @@ OBJ += requirements.txt
 OBJ += pyproject.toml
 OBJ += README.md
 
+.PHONY: clean
 clean:
 	if [ -d .venv/mnt ] && mountpoint -q .venv/mnt; then \
 	    umount -ql .venv/mnt; \
 	fi
 	git clean --force -dX
 
+.PHONY: build
 build: executable
 
+.PHONY: release
 release: build
 
 dist:
@@ -45,29 +48,20 @@ dist/vbuild: dist vbuild/cli/__names__.py $(OBJ)
 	    --output-filename=vbuild \
 	    vbuild
 
+.PHONY: executable
 executable: dist/vbuild
 
+.PHONY: test
 test: $(IMAGES) $(OBJ)
 	emake requirements
 	. ${VENV_BIN_ACTIVATE}; \
 	python -u test.py
 
+.PHONY: all
 all: release
 
+.PHONY: builder
 builder:
 	podman build \
 	  --tag=ghcr.io/eeems/vbuild-builder \
 	  builder/
-
-.PHONY: \
-	all \
-	build \
-	clean \
-	executable \
-	release \
-	test \
-	lint \
-	lint-fix \
-	format \
-	format-fix \
-	builder

--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,7 @@ dist:
 	mkdir -p dist
 
 ${VENV_BIN_ACTIVATE}: requirements.txt
-	@echo "Setting up development virtual env in .venv"
-	python -m venv .venv
-	. ${VENV_BIN_ACTIVATE}; \
-	python -m pip install wheel build ruff; \
-	python -m pip install \
-	    --extra-index-url=https://wheels.eeems.codes/ \
-	    -r requirements.txt
+	emake requirements
 
 vbuild/cli/__names__.py: ${VENV_BIN_ACTIVATE} $(OBJ)
 	. ${VENV_BIN_ACTIVATE}; \
@@ -59,22 +53,6 @@ test: ${VENV_BIN_ACTIVATE} $(IMAGES) $(OBJ)
 	python -u test.py
 
 all: release
-
-lint: $(VENV_BIN_ACTIVATE)
-	. $(VENV_BIN_ACTIVATE); \
-	python -m ruff check
-
-lint-fix: $(VENV_BIN_ACTIVATE)
-	. $(VENV_BIN_ACTIVATE); \
-	python -m ruff check --fix
-
-format: $(VENV_BIN_ACTIVATE)
-	. $(VENV_BIN_ACTIVATE); \
-	python -m ruff format --diff
-
-format-fix: $(VENV_BIN_ACTIVATE)
-	. $(VENV_BIN_ACTIVATE); \
-	python -m ruff format
 
 builder:
 	podman build \

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ dist:
 	mkdir -p dist
 
 vbuild/cli/__names__.py: $(OBJ)
+	emake requirements
 	. ${VENV_BIN_ACTIVATE}; \
 	python -u write_cli_names.py
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ PYTHON := python
 endif
 
 OBJ := $(wildcard ${PACKAGE}/**)
-OBJ += requirements.txt
 OBJ += pyproject.toml
 OBJ += README.md
 

--- a/Makefile
+++ b/Makefile
@@ -35,18 +35,6 @@ vbuild/cli/__names__.py: $(OBJ)
 	. ${VENV_BIN_ACTIVATE}; \
 	python -u write_cli_names.py
 
-dist/vbuild: dist vbuild/cli/__names__.py $(OBJ)
-	emake requirements
-	. ${VENV_BIN_ACTIVATE}; \
-	python -m pip install wheel nuitka zstandard; \
-	NUITKA_CACHE_DIR="$(realpath .)/.nuitka" \
-	nuitka \
-	    --assume-yes-for-downloads \
-	    --remove-output \
-	    --output-dir=dist \
-	    --output-filename=vbuild \
-	    vbuild
-
 .PHONY: executable
 executable: dist/vbuild
 

--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,6 @@ vbuild/cli/__names__.py: $(OBJ)
 	. ${VENV_BIN_ACTIVATE}; \
 	python -u write_cli_names.py
 
-.PHONY: executable
-executable: dist/vbuild
-
 .PHONY: test
 test: $(IMAGES) $(OBJ)
 	emake requirements

--- a/Makefile
+++ b/Makefile
@@ -28,14 +28,12 @@ release: build
 dist:
 	mkdir -p dist
 
-${VENV_BIN_ACTIVATE}: requirements.txt
-	emake requirements
-
-vbuild/cli/__names__.py: ${VENV_BIN_ACTIVATE} $(OBJ)
+vbuild/cli/__names__.py: $(OBJ)
 	. ${VENV_BIN_ACTIVATE}; \
 	python -u write_cli_names.py
 
-dist/vbuild: dist vbuild/cli/__names__.py ${VENV_BIN_ACTIVATE} $(OBJ)
+dist/vbuild: dist vbuild/cli/__names__.py $(OBJ)
+	emake requirements
 	. ${VENV_BIN_ACTIVATE}; \
 	python -m pip install wheel nuitka zstandard; \
 	NUITKA_CACHE_DIR="$(realpath .)/.nuitka" \
@@ -48,7 +46,8 @@ dist/vbuild: dist vbuild/cli/__names__.py ${VENV_BIN_ACTIVATE} $(OBJ)
 
 executable: dist/vbuild
 
-test: ${VENV_BIN_ACTIVATE} $(IMAGES) $(OBJ)
+test: $(IMAGES) $(OBJ)
+	emake requirements
 	. ${VENV_BIN_ACTIVATE}; \
 	python -u test.py
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 description = "Build system used for vellum"
 license = "MIT"
-requires-python = ">=3.12,<3.14"
+requires-python = ">=3.12,<3.15"
 classifiers = [
     "Development Status :: 5 - Alpha",
     "Intended Audience :: Developers",
@@ -14,6 +14,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development :: Build Tools",
     "Topic :: System :: Archiving :: Packaging",
@@ -29,13 +30,14 @@ dynamic = ["dependencies", "readme"]
 "Homepage" = "https://github.com/Eeems/vbuild"
 "Bug Tracker" = "https://github.com/Eeems/vbuild/issues"
 
+[project.optional-dependencies]
+test = ["pytest"]
+
 [project.scripts]
 vbuild = "vbuild.__main__:main"
 
 [tool.setuptools]
-packages = [
-    "vbuild",
-]
+packages = ["vbuild"]
 
 [tool.setuptools.package-data]
 vbuild = ["py.typed", "*.py.typed"]
@@ -45,8 +47,36 @@ dependencies = {file = ["requirements.txt"]}
 readme = {file= ["README.md"], content-type = "text/markdown"}
 
 [build-system]
-requires = [
-    "setuptools>=80",
-    "wheel"
+requires = ["setuptools>=77.0", "nuitka>=4.0.6"]
+build-backend = "nuitka.distutils.Build"
+
+
+[tool.ruff]
+exclude = [".venv", "build"]
+
+[tool.ruff.lint]
+extend-select = [
+    "UP",
+    "PL",
+    "ANN",
+    "S",
 ]
-build-backend = "setuptools.build_meta"
+ignore = [
+    "PLW0603",
+    "PLR2004",
+    "PLR0915",
+    "PLR0912",
+    "PLR0911",
+    "PLR6301",
+    "PLR0913",
+    "S101",
+    "S404",
+    "S603",
+    "S607",
+    "ANN401",
+    "ANN001",
+    "ANN003",
+]
+
+[tool.pyright]
+exclude = [".venv", "build"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,13 @@ keywords = [
     "packaging",
     "distribution",
 ]
-dynamic = ["dependencies", "readme"]
+dynamic = ["readme"]
+dependencies = [
+    "pyelftools==0.32",
+    "docker==7.1.0",
+    "podman==5.7.0",
+    "rich-argparse==1.7.2",
+]
 
 [project.urls]
 "Homepage" = "https://github.com/Eeems/vbuild"
@@ -43,7 +49,6 @@ packages = ["vbuild"]
 vbuild = ["py.typed", "*.py.typed"]
 
 [tool.setuptools.dynamic]
-dependencies = {file = ["requirements.txt"]}
 readme = {file= ["README.md"], content-type = "text/markdown"}
 
 [build-system]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-pyelftools==0.32
-docker==7.1.0
-podman==5.7.0
-rich-argparse==1.7.2

--- a/test.py
+++ b/test.py
@@ -2,23 +2,24 @@ from __future__ import annotations
 
 import sys
 import traceback
-
-from typing import Callable
+from collections.abc import Callable
 from typing import Any
 
-from vbuild.apkbuild import quoted_string  # pyright: ignore[reportImplicitRelativeImport]
-from vbuild.apkbuild import APKBUILD  # pyright: ignore[reportImplicitRelativeImport]
-from vbuild.apkbuild import StringProperty  # pyright: ignore[reportImplicitRelativeImport]
-from vbuild.apkbuild import StringArrayProperty  # pyright: ignore[reportImplicitRelativeImport]
+from vbuild.apkbuild import (
+    APKBUILD,
+    StringArrayProperty,
+    StringProperty,
+    quoted_string,
+)
 
 FAILED = False
 
 
-def _assert(source: str, debug: Callable[[], Any] | None = None):  # pyright: ignore[reportExplicitAny]
+def _assert(source: str, debug: Callable[[], Any] | None = None) -> None:  # pyright: ignore[reportExplicitAny]
     global FAILED
     print(f"check {source}: ", end="")
     try:
-        if eval(source):
+        if eval(source):  # noqa: S307
             print("pass")
             return
 
@@ -34,11 +35,15 @@ def _assert(source: str, debug: Callable[[], Any] | None = None):  # pyright: ig
         print(f"  {debug()}")
 
 
-def _raises(source: str, exc: type[Exception], debug: Callable[[], Any] | None = None):  # pyright: ignore[reportExplicitAny]
+def _raises(
+    source: str,
+    exc: type[Exception],
+    debug: Callable[[], Any] | None = None,  # pyright: ignore[reportExplicitAny]
+) -> None:
     global FAILED
     print(f"check {source} raises {exc.__name__}: ", end="")
     try:
-        eval(source)
+        eval(source)  # noqa: S307
         FAILED = True  # pyright: ignore[reportConstantRedefinition]
         print("fail")
         if debug is not None:
@@ -53,11 +58,11 @@ def _raises(source: str, exc: type[Exception], debug: Callable[[], Any] | None =
         traceback.print_exc()
 
 
-def _isinstance(source: str, cls: type, debug: Callable[[], Any] | None = None):  # pyright: ignore[reportExplicitAny]
+def _isinstance(source: str, cls: type, debug: Callable[[], Any] | None = None) -> None:  # pyright: ignore[reportExplicitAny]
     global FAILED
     print(f"checking that {source} is {cls.__name__}: ", end="")
     try:
-        value = eval(source)  # pyright: ignore[reportAny]
+        value = eval(source)  # pyright: ignore[reportAny]  # noqa: S307
         if isinstance(value, cls):
             print("pass")
             return

--- a/vbuild/__main__.py
+++ b/vbuild/__main__.py
@@ -1,10 +1,9 @@
 # nuitka-project: --enable-plugin=pylint-warnings
 ## nuitka-project: --enable-plugin=upx
 # nuitka-project: --warn-implicit-exceptions
-# nuitka-project: --onefile
 # nuitka-project: --lto=yes
-# nuitka-project:--python-flag=-m
 # nuitka-project:--include-package=vbuild.cli
+# nuitka-project:--report=build/report.xml
 import sys
 
 from .cli import main

--- a/vbuild/abuild.py
+++ b/vbuild/abuild.py
@@ -17,7 +17,6 @@ from . import containers
 KEY_NAME = os.environ.get("VBUILD_KEY_NAME", "vbuild")
 
 SETUP_CONTAINER = [
-    "set -e",
     f"cp /root/.abuild/{KEY_NAME}.rsa.pub /etc/apk/keys/",
     'mkdir -p /dist/"$CARCH" /work/src',
 ]
@@ -119,7 +118,7 @@ def abuild(
             "ghcr.io/eeems/vbuild-builder:main",
             [
                 "sh",
-                "-c",
+                "-ec",
                 "\n".join(
                     [
                         *SETUP_CONTAINER,

--- a/vbuild/abuild.py
+++ b/vbuild/abuild.py
@@ -2,7 +2,10 @@ import os
 import shlex
 import subprocess
 import sys
-from collections.abc import Generator, Iterator
+from collections.abc import (
+    Generator,
+    Iterator,
+)
 from hashlib import sha256
 from typing import Any
 
@@ -53,7 +56,7 @@ def abuild(
     conf_path = os.path.join(abuilddir, "abuild.conf")
     lines: list[str] = [f"PACKAGER_PRIVKEY=/root/.abuild/{KEY_NAME}.rsa\n"]
     if os.path.exists(conf_path):
-        with open(conf_path, "r") as f:
+        with open(conf_path) as f:
             for line in f.readlines():
                 if not line.startswith("PACKAGER_PRIVKEY="):
                     lines.append(line)
@@ -77,9 +80,9 @@ def abuild(
             logs = containers.pull(client, "ghcr.io/eeems/vbuild-builder", "main")
             for x in logs:
                 if isinstance(x, bytes):
-                    x = x.decode()
+                    x = x.decode()  # noqa: PLW2901
 
-                x = x.strip()
+                x = x.strip()  # noqa: PLW2901
                 if x:
                     print(x, file=sys.stderr)
 
@@ -133,10 +136,10 @@ def abuild(
             logs = container.logs(stream=True)  # pyright: ignore[reportUnknownMemberType]
             for x in logs:
                 if isinstance(x, bytes):
-                    x = x.decode()
+                    x = x.decode()  # noqa: PLW2901
 
                 assert isinstance(x, str)
-                x = x.strip()
+                x = x.strip()  # noqa: PLW2901
                 if x:
                     print(x, file=sys.stderr)
 
@@ -152,7 +155,7 @@ def abuild(
                 try:
                     container.stop()  # pyright: ignore[reportUnknownMemberType]
 
-                except Exception:
+                except Exception:  # noqa: S110
                     pass
 
             container.remove()  # pyright: ignore[reportUnknownMemberType]

--- a/vbuild/apkbuild.py
+++ b/vbuild/apkbuild.py
@@ -115,8 +115,8 @@ def quoted_string(value: str) -> str:
         token = value[offset]
         offset += 1
 
-        if token != "$":
-            if token != "'":
+        if token != "$":  # noqa: S105
+            if token != "'":  # noqa: S105
                 if not in_quote:
                     in_quote = True
                     quoted_value += "'"
@@ -140,7 +140,7 @@ def quoted_string(value: str) -> str:
             source += name
             offset, next_token = get_token(value, offset)
             source += next_token
-            if next_token != "}" and offset < size:
+            if next_token != "}" and offset < size:  # noqa: S105
                 raise bash.BashSyntaxError(
                     f"Unexpected token: '{next_token}'. Expecting '}}'", value, 1
                 )
@@ -498,7 +498,7 @@ class APKBUILD:
 
 
 def parse(path: str) -> APKBUILD:
-    with open(path, "r") as f:
+    with open(path) as f:
         variables, functions = bash.parse(f.read())
 
     return APKBUILD(variables, functions)

--- a/vbuild/bash.py
+++ b/vbuild/bash.py
@@ -3,7 +3,6 @@
 import os
 import shlex
 import subprocess
-
 from io import StringIO
 from typing import cast
 
@@ -132,7 +131,13 @@ class BashSyntaxError(Exception):
 def run_bash(src: str, env: dict[str, str] | None = None) -> str:
     env = {} if env is None else env.copy()
     env["PATH"] = os.environ["PATH"]
-    process = subprocess.run(["bash"], input=src.encode(), capture_output=True, env=env)
+    process = subprocess.run(
+        ["bash"],
+        input=src.encode(),
+        capture_output=True,
+        env=env,
+        check=False,
+    )
     errors = process.stderr.decode()
     if process.returncode == 2 or "syntax error" in errors:
         raise BashSyntaxError(errors, src, 0)
@@ -168,19 +173,19 @@ def parse(src: str, env: dict[str, str] | None = None) -> tuple[Variables, Funct
         next_token = lexer.get_token()
         assert next_token is not None
 
-        if token == "declare" and next_token[0] == "-":
+        if token == "declare" and next_token[0] == "-":  # noqa: S105
             lexer.push_token(next_token)
             name, value = parse_variable(lexer)
             variables[name] = value
             continue
 
-        if next_token != "(":
+        if next_token != "(":  # noqa: S105
             raise BashSyntaxError(
                 f"Unexpected token: '{next_token}'. Expecting '('", src, lexer.lineno
             )
 
         following_token = lexer.get_token()
-        if following_token != ")":
+        if following_token != ")":  # noqa: S105
             raise BashSyntaxError(
                 f"Unexpected token: '{next_token}'. Expecting ')'", src, lexer.lineno
             )
@@ -217,7 +222,7 @@ def parse_function(lexer: shlex.shlex) -> tuple[int, int]:
 
 def get_string(lexer: shlex.shlex) -> str:
     string_token = lexer.get_token() or ""
-    if string_token == "$":
+    if string_token == "$":  # noqa: S105
         quoted_string = lexer.get_token() or ""
         string_token = run_bash("echo -n $" + shlex.quote(quoted_string))
 
@@ -227,13 +232,13 @@ def get_string(lexer: shlex.shlex) -> str:
 def parse_variable(lexer: shlex.shlex) -> tuple[str, VariableValue]:
     flags_token = lexer.get_token()
     assert flags_token is not None
-    flags: set[str] = set(flags_token[1:]) if flags_token != "--" else set()
+    flags: set[str] = set(flags_token[1:]) if flags_token != "--" else set()  # noqa: S105
     name = lexer.get_token()
     assert name is not None
     value: VariableValue = None
     next_token = lexer.get_token()
     assert next_token is not None
-    if next_token != "=":
+    if next_token != "=":  # noqa: S105
         lexer.push_token(next_token)
         return name, value
 
@@ -259,10 +264,10 @@ def parse_indexed(lexer: shlex.shlex) -> IndexedArray:
     while True:
         token = lexer.get_token()
         assert token != lexer.eof
-        if token == ")":
+        if token == ")":  # noqa: S105
             break
 
-        assert token == "["
+        assert token == "["  # noqa: S105
         index = int(lexer.get_token() or "")
         _ = assert_token(lexer, "]")
         _ = assert_token(lexer, "=")
@@ -281,10 +286,10 @@ def parse_associative(lexer: shlex.shlex) -> AssociativeArray:
     while True:
         token = lexer.get_token()
         assert token != lexer.eof
-        if token == ")":
+        if token == ")":  # noqa: S105
             break
 
-        assert token == "["
+        assert token == "["  # noqa: S105
         key = lexer.get_token()
         assert key is not None
         _ = assert_token(lexer, "]")

--- a/vbuild/cli/__init__.py
+++ b/vbuild/cli/__init__.py
@@ -15,21 +15,18 @@ from .__modules__ import (
 def main() -> int:
     try:
         parser = argparse.ArgumentParser(
-            epilog=str(
-                Markdown(
-                    """
-            ENVIRONMENT VARIBLES:
-            ---------------------
+            epilog=Markdown(  # pyright: ignore[reportArgumentType]
+                """
+### ENVIRONMENT VARIABLES:
 
-              | Name | Description |
-              | ---- | ---------- |
-              | `$REPODEST` | Packages shall be stored in `$REPODEST/$repo/$arch/$pkgname-$pkgver-r$pkgrel.apk`, where `$repo` is the base name of the parent directory of `$startdir`. |
-              | `$CARCH` | Architecture to compile package as. |
-              | `$VBUILD_KEY_NAME` | Key name to use when signing packages. |
-              | `$VBUILD_DRIVER` | Driver to use for running containers. Possible values are `podman` and `docker`. |
-                        """,
-                    style="argeparse.txt",
-                )
+| Name | Description |
+| ---- | ---------- |
+| `$REPODEST` | Packages shall be stored in `$REPODEST/$repo/$arch/$pkgname-$pkgver-r$pkgrel.apk`, where `$repo` is the base name of the parent directory of `$startdir`. |
+| `$CARCH` | Architecture to compile package as. |
+| `$VBUILD_KEY_NAME` | Key name to use when signing packages. |
+| `$VBUILD_DRIVER` | Driver to use for running containers. Possible values are `podman` and `docker`. |
+                    """,
+                style="argparse.txt",
             ),
             formatter_class=RichHelpFormatter,
         )

--- a/vbuild/cli/__init__.py
+++ b/vbuild/cli/__init__.py
@@ -1,31 +1,35 @@
 import argparse
-
-from typing import cast
 from subprocess import CalledProcessError
-from rich_argparse import RichHelpFormatter
-from rich.markdown import Markdown
+from typing import cast
 
-from .__modules__ import modules
-from .__modules__ import commands
-from .__modules__ import CommandCallable
+from rich.markdown import Markdown
+from rich_argparse import RichHelpFormatter
+
+from .__modules__ import (
+    CommandCallable,
+    commands,
+    modules,
+)
 
 
 def main() -> int:
     try:
         parser = argparse.ArgumentParser(
-            epilog=Markdown(
-                """
-ENVIRONMENT VARIBLES:
----------------------
+            epilog=str(
+                Markdown(
+                    """
+            ENVIRONMENT VARIBLES:
+            ---------------------
 
-  | Name | Description |
-  | ---- | ---------- |
-  | `$REPODEST` | Packages shall be stored in `$REPODEST/$repo/$arch/$pkgname-$pkgver-r$pkgrel.apk`, where `$repo` is the base name of the parent directory of `$startdir`. |
-  | `$CARCH` | Architecture to compile package as. |
-  | `$VBUILD_KEY_NAME` | Key name to use when signing packages. |
-  | `$VBUILD_DRIVER` | Driver to use for running containers. Possible values are `podman` and `docker`. |
-            """,
-                style="argeparse.txt",
+              | Name | Description |
+              | ---- | ---------- |
+              | `$REPODEST` | Packages shall be stored in `$REPODEST/$repo/$arch/$pkgname-$pkgver-r$pkgrel.apk`, where `$repo` is the base name of the parent directory of `$startdir`. |
+              | `$CARCH` | Architecture to compile package as. |
+              | `$VBUILD_KEY_NAME` | Key name to use when signing packages. |
+              | `$VBUILD_DRIVER` | Driver to use for running containers. Possible values are `podman` and `docker`. |
+                        """,
+                    style="argeparse.txt",
+                )
             ),
             formatter_class=RichHelpFormatter,
         )
@@ -58,3 +62,6 @@ ENVIRONMENT VARIBLES:
             print(e.stderr)  # pyright: ignore[reportAny]
 
         raise
+
+
+__all__ = ["commands", "main"]

--- a/vbuild/cli/__modules__.py
+++ b/vbuild/cli/__modules__.py
@@ -1,8 +1,8 @@
-import os
 import argparse
 import importlib
+import os
+from collections.abc import Callable
 from glob import glob
-from typing import Callable
 from types import ModuleType
 
 CommandCallable = Callable[[argparse.Namespace], int]
@@ -11,7 +11,15 @@ commands: dict[str, CommandCallable] = {}
 
 names: list[str] = []
 if "__compiled__" in globals():
-    from .__names__ import names
+    from typing import cast
+
+    from .__names__ import (  # pyright: ignore[reportMissingImports]
+        names,  # pyright: ignore[ reportUnknownVariableType]
+    )
+
+    assert isinstance(names, list)
+    assert all([isinstance(x, str) for x in names])  # pyright: ignore[reportUnknownVariableType]
+    names = cast(list[str], names)
 
 else:
     __dirname__ = os.path.dirname(__file__)

--- a/vbuild/cli/__modules__.py
+++ b/vbuild/cli/__modules__.py
@@ -1,3 +1,4 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=false
 import argparse
 import importlib
 import os
@@ -19,7 +20,7 @@ if "__compiled__" in globals():
 
     assert isinstance(names, list)
     assert all([isinstance(x, str) for x in names])  # pyright: ignore[reportUnknownVariableType]
-    names = cast(list[str], names)
+    names = cast(list[str], names)  # pyright: ignore[reportUnnecessaryCast]
 
 else:
     __dirname__ = os.path.dirname(__file__)

--- a/vbuild/cli/__template__.py
+++ b/vbuild/cli/__template__.py
@@ -1,12 +1,14 @@
-from argparse import ArgumentParser
-from argparse import Namespace
+from argparse import (
+    ArgumentParser,
+    Namespace,
+)
 
 kwds: dict[str, str] = {
     "help": "What does this do?",
 }
 
 
-def register(_: ArgumentParser):
+def register(_: ArgumentParser) -> None:
     pass
 
 

--- a/vbuild/cli/all.py
+++ b/vbuild/cli/all.py
@@ -1,5 +1,7 @@
-from argparse import ArgumentParser
-from argparse import Namespace
+from argparse import (
+    ArgumentParser,
+    Namespace,
+)
 
 from .__modules__ import commands
 
@@ -8,7 +10,7 @@ kwds: dict[str, str] = {
 }
 
 
-def register(_: ArgumentParser):
+def register(_: ArgumentParser) -> None:
     pass
 
 

--- a/vbuild/cli/build.py
+++ b/vbuild/cli/build.py
@@ -1,5 +1,7 @@
-from argparse import ArgumentParser
-from argparse import Namespace
+from argparse import (
+    ArgumentParser,
+    Namespace,
+)
 from typing import cast
 
 from ..abuild import abuild
@@ -9,7 +11,7 @@ kwds: dict[str, str] = {
 }
 
 
-def register(_: ArgumentParser):
+def register(_: ArgumentParser) -> None:
     pass
 
 

--- a/vbuild/cli/check.py
+++ b/vbuild/cli/check.py
@@ -1,5 +1,7 @@
-from argparse import ArgumentParser
-from argparse import Namespace
+from argparse import (
+    ArgumentParser,
+    Namespace,
+)
 from typing import cast
 
 from ..abuild import abuild
@@ -9,7 +11,7 @@ kwds: dict[str, str] = {
 }
 
 
-def register(_: ArgumentParser):
+def register(_: ArgumentParser) -> None:
     pass
 
 

--- a/vbuild/cli/checksum.py
+++ b/vbuild/cli/checksum.py
@@ -1,6 +1,9 @@
 import os
 import shlex
-from argparse import ArgumentParser, Namespace
+from argparse import (
+    ArgumentParser,
+    Namespace,
+)
 from typing import cast
 
 from ..abuild import abuild
@@ -13,7 +16,7 @@ kwds: dict[str, str] = {
 }
 
 
-def register(_: ArgumentParser):
+def register(_: ArgumentParser) -> None:
     pass
 
 
@@ -32,13 +35,15 @@ def command(args: Namespace) -> int:
     checksums = apkbuild.sha512sums  # pyright: ignore[reportAny]
     assert checksums is not None
     assert isinstance(checksums, list)
+    assert all([isinstance(x, str) for x in checksums])  # pyright: ignore[reportUnknownVariableType]
+    checksums = cast(list[str], checksums)
     velbuild_path = os.path.join(directory, "VELBUILD")
     velbuild = parse_velbuild(velbuild_path)
     print(f">>> {velbuild.pkgname}: Updating the sha512sums in {velbuild_path}...")  # pyright: ignore[reportAny]
     if velbuild.sha512sums == checksums:  # pyright: ignore[reportAny]
         return 0
 
-    with open(velbuild_path, "r") as f:
+    with open(velbuild_path) as f:
         lines_in = f.readlines()
 
     in_block = False

--- a/vbuild/cli/clean.py
+++ b/vbuild/cli/clean.py
@@ -1,5 +1,7 @@
-from argparse import ArgumentParser
-from argparse import Namespace
+from argparse import (
+    ArgumentParser,
+    Namespace,
+)
 from typing import cast
 
 from ..abuild import abuild
@@ -9,7 +11,7 @@ kwds: dict[str, str] = {
 }
 
 
-def register(_: ArgumentParser):
+def register(_: ArgumentParser) -> None:
     pass
 
 

--- a/vbuild/cli/fetch.py
+++ b/vbuild/cli/fetch.py
@@ -1,5 +1,7 @@
-from argparse import ArgumentParser
-from argparse import Namespace
+from argparse import (
+    ArgumentParser,
+    Namespace,
+)
 from typing import cast
 
 from ..abuild import abuild
@@ -9,7 +11,7 @@ kwds: dict[str, str] = {
 }
 
 
-def register(_: ArgumentParser):
+def register(_: ArgumentParser) -> None:
     pass
 
 

--- a/vbuild/cli/gen.py
+++ b/vbuild/cli/gen.py
@@ -1,7 +1,8 @@
 import os
-
-from argparse import ArgumentParser
-from argparse import Namespace
+from argparse import (
+    ArgumentParser,
+    Namespace,
+)
 from typing import cast
 
 from ..apkbuild import ErrorType
@@ -12,7 +13,7 @@ kwds: dict[str, str] = {
 }
 
 
-def register(_: ArgumentParser):
+def register(_: ArgumentParser) -> None:
     pass
 
 

--- a/vbuild/cli/prepare.py
+++ b/vbuild/cli/prepare.py
@@ -1,5 +1,7 @@
-from argparse import ArgumentParser
-from argparse import Namespace
+from argparse import (
+    ArgumentParser,
+    Namespace,
+)
 from typing import cast
 
 from ..abuild import abuild
@@ -9,7 +11,7 @@ kwds: dict[str, str] = {
 }
 
 
-def register(_: ArgumentParser):
+def register(_: ArgumentParser) -> None:
     pass
 
 

--- a/vbuild/cli/rootpkg.py
+++ b/vbuild/cli/rootpkg.py
@@ -1,5 +1,7 @@
-from argparse import ArgumentParser
-from argparse import Namespace
+from argparse import (
+    ArgumentParser,
+    Namespace,
+)
 from typing import cast
 
 from ..abuild import abuild
@@ -9,7 +11,7 @@ kwds: dict[str, str] = {
 }
 
 
-def register(_: ArgumentParser):
+def register(_: ArgumentParser) -> None:
     pass
 
 

--- a/vbuild/cli/unpack.py
+++ b/vbuild/cli/unpack.py
@@ -1,5 +1,7 @@
-from argparse import ArgumentParser
-from argparse import Namespace
+from argparse import (
+    ArgumentParser,
+    Namespace,
+)
 from typing import cast
 
 from ..abuild import abuild
@@ -9,7 +11,7 @@ kwds: dict[str, str] = {
 }
 
 
-def register(_: ArgumentParser):
+def register(_: ArgumentParser) -> None:
     pass
 
 

--- a/vbuild/cli/validate.py
+++ b/vbuild/cli/validate.py
@@ -1,19 +1,22 @@
 import os
-
-from argparse import ArgumentParser
-from argparse import Namespace
+from argparse import (
+    ArgumentParser,
+    Namespace,
+)
 from typing import cast
 
 from ..abuild import abuild
-from ..apkbuild import parse
-from ..apkbuild import ErrorType
+from ..apkbuild import (
+    ErrorType,
+    parse,
+)
 
 kwds: dict[str, str] = {
     "help": "check the APKBUILD file for violations of policy, superfluous statements, stylistic violations and others",
 }
 
 
-def register(_: ArgumentParser):
+def register(_: ArgumentParser) -> None:
     pass
 
 

--- a/vbuild/containers.py
+++ b/vbuild/containers.py
@@ -1,12 +1,11 @@
-import podman
-import docker
 import json
 import os
-
-from contextlib import contextmanager
 from collections.abc import Generator
-from typing import cast
-from typing import Any
+from contextlib import contextmanager
+from typing import Any, cast
+
+import docker
+import podman
 
 
 def parse_progress(x: dict[str, Any]) -> str:  # pyright: ignore[reportExplicitAny]
@@ -38,8 +37,8 @@ def pull(
     assert isinstance(logs, Generator), f"Not a generator: {logs}"
     for x in logs:  # pyright: ignore[reportUnknownVariableType]
         yield parse_progress(
-            json.loads(x) if isinstance(client, podman.PodmanClient) else x
-        )  # pyright: ignore[reportArgumentType, reportUnknownArgumentType]
+            json.loads(x) if isinstance(client, podman.PodmanClient) else x  # pyright: ignore[reportArgumentType, reportUnknownArgumentType]
+        )
 
 
 @contextmanager

--- a/vbuild/velbuild.py
+++ b/vbuild/velbuild.py
@@ -37,7 +37,7 @@ class VELBUILD(APKBUILD):
         lines: list[str] = []
         variables = self.variables.copy()
 
-        if self.systemdunits and (self.options is None or "!fhs" not in self.options):
+        if self.systemdunits and (self.options is None or "!fhs" not in self.options):  # pyright: ignore[reportAny]
             variables["options"] = f"\n{'\n'.join([*(self.options or []), '!fhs'])}\n"
 
         for name, value in variables.items():
@@ -58,7 +58,7 @@ class VELBUILD(APKBUILD):
                 continue
 
             if name in ("upstream_author", "category"):
-                name = f"_{name}"
+                name = f"_{name}"  # noqa: PLW2901
 
             if isinstance(value, str):
                 lines.append(f"{name}={quoted_string(value)}")
@@ -93,18 +93,18 @@ class VELBUILD(APKBUILD):
                 continue
 
             if name == "package" and (
-                self.postosupgrade is not None or self.systemdunits
+                self.postosupgrade is not None or self.systemdunits  # pyright: ignore[reportAny]
             ):
                 fn_name = INSTALL_FUNCTION_NAME_MAP["postosupgrade"]
                 value += f'{tab}install -Dm755 "$startdir"/"$pkgname".{fn_name} '  # noqa: PLW2901
-                value += (
+                value += (  # noqa: PLW2901
                     '"$pkgdir"/home/root/.vellum/hooks/post-os-upgrade/"$pkgname";\n'  # noqa: PLW2901
                 )
 
             if name == "package":
                 for unit in self.systemdunits:  # pyright: ignore[reportAny]
-                    unit_name = os.path.basename(unit)
-                    value += f'{tab}install -Dm644 "$srcdir/{unit}" "$pkgdir/home/root/.vellum/share/{self.pkgname}/{unit_name}";\n'
+                    unit_name = os.path.basename(unit)  # pyright: ignore[reportAny]
+                    value += f'{tab}install -Dm644 "$srcdir/{unit}" "$pkgdir/home/root/.vellum/share/{self.pkgname}/{unit_name}";\n'  # noqa: PLW2901  # pyright: ignore[reportAny]
 
             lines.append(f"{name}() {{{value}}}")
 
@@ -118,7 +118,7 @@ class VELBUILD(APKBUILD):
 
         return "\n".join(lines)
 
-    def save(self, path: str):
+    def save(self, path: str) -> None:
         assert isinstance(self.pkgname, str)  # pyright: ignore[reportAny]
         with open(os.path.join(path, "APKBUILD"), "w") as f:
             _ = f.write(self.text + "\n")
@@ -126,7 +126,7 @@ class VELBUILD(APKBUILD):
         for name, _ in INSTALL_FUNCTION_NAME_MAP.items():
             src = getattr(self, name)  # pyright: ignore[reportAny]
 
-            footer = self._getfooter(self.pkgname, name, self.systemdunits)
+            footer = self._getfooter(self.pkgname, name, self.systemdunits)  # pyright: ignore[reportAny]
             if src is None and footer is None:
                 continue
 
@@ -406,7 +406,7 @@ class VELBUILD(APKBUILD):
 
 
 def parse(path: str) -> VELBUILD:
-    with open(path, "r") as f:
+    with open(path) as f:
         variables, functions = bash.parse(f.read(), APKBUILD_AUTOMATIC_VARIABLES)
 
     return VELBUILD(variables, functions)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds support for Python 3.14.

* **Chores**
  * Moves build backend to Nuitka and pins runtime dependencies in project config.
  * Consolidates executable builds for glibc and musl; CI now produces and consumes unified artifacts.
  * Removes Makefile lint/format targets and updates virtualenv/bootstrap steps to use the new toolchain.
* **Tests**
  * CI uses containerized test runs and installs requirements via the build tool before activation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->